### PR TITLE
去掉createSagaMiddleware() 中参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ import createSagaMiddleware from 'redux-saga'
 import reducer from './reducers'
 import mySaga from './sagas'
 
-const sagaMiddleware = createSagaMiddleware(mySaga)
+const sagaMiddleware = createSagaMiddleware()
 const store = createStore(
   reducer,
   applyMiddleware(sagaMiddleware)
 )
+sagaMiddleware.run(mySaga)
 
 // render the application
 ```
@@ -217,4 +218,3 @@ npm run real-world
 - [Kevin He@kevinxh](https://github.com/kevinxh)
 
 **如果看到翻译不准确、句子不通顺的地方，欢迎随时指出。本文档翻译流程按照 [ETC 翻译规范](https://github.com/react-guide/ETC)，欢迎你来一起完善。**
-

--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -66,10 +66,12 @@ import createSagaMiddleware from 'redux-saga'
 //...
 import { helloSaga } from './sagas'
 
+const sagaMiddleware = createSagaMiddleware()
 const store = createStore(
   reducer,
-  applyMiddleware(createSagaMiddleware(helloSaga))
+  applyMiddleware(sagaMiddleware)
 )
+sagaMiddleware.run(helloSaga)
 
 // rest unchanged
 ```

--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -76,8 +76,8 @@ sagaMiddleware.run(helloSaga)
 // rest unchanged
 ```
 
-首先我们引入 `./sagas` 模块中的 Saga。然后使用 `redux-saga` 模块的 `createSagaMiddleware` 工厂函数来创建一个 Saga middleware。
-`createSagaMiddleware` 接受 Sagas 列表，这些 Sagas 将会通过创建的 middleware 被立即执行。
+首先我们引入 `./sagas` 模块中的 Saga。然后使用 `redux-saga` 模块的 `createSagaMiddleware` 工厂函数来创建一个 Saga middleware 实例sagaMiddleware。
+通过调用创建的sagaMiddleware实例方法run(helloSaga) 来执行saga。
 
 
 到目前为止，我们的 Saga 并没做什么特别的事情。它只是打印了一条消息，然后退出。


### PR DESCRIPTION
saga从0.10后不再支持把自定义的saga以参数方式传进createSagaMiddleware了。

想要运行saga，需要手动执行run(yourSaga)