### PR TITLE
文档代码缺失

### DIFF
--- a/docs/advanced/NonBlockingCalls.md
+++ b/docs/advanced/NonBlockingCalls.md
@@ -152,6 +152,7 @@ function* authorize(user, password) {
   try {
     const token = yield call(Api.authorize, user, password)
     yield put({type: 'LOGIN_SUCCESS', token})
+    yield call(Api.storeItem, {token})
   } catch(error) {
     yield put({type: 'LOGIN_ERROR', error})
   }

--- a/docs/advanced/NonBlockingCalls.md
+++ b/docs/advanced/NonBlockingCalls.md
@@ -152,7 +152,7 @@ function* authorize(user, password) {
   try {
     const token = yield call(Api.authorize, user, password)
     yield put({type: 'LOGIN_SUCCESS', token})
-    yield call(Api.storeItem, {token})
+    return token
   } catch(error) {
     yield put({type: 'LOGIN_ERROR', error})
   }


### PR DESCRIPTION
少了一行将 token 存储操作移到 authorize 任务内部的代码